### PR TITLE
Change color of Status Bar - NEO active connect

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,3 +7,14 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode"
 }
+  //Adding the following code allows us to change the colors on the status bar at the bottom of the VS Code border to whatever we like
+  "workbench.colorCustomizations": {
+    "statusBar.background": "#1A1A1A",
+    "statusBar.noFolderBackground": "#212121",
+    "statusBar.debuggingBackground": "#263238",
+    "statusBarItem.prominentForeground": "#55eb34",
+
+    "statusBar.foreground": "#ce8416"
+  },
+
+}


### PR DESCRIPTION
I added code to the settings.json file which changes the colors on the status bar at the bottom of the VS Code border based on Active Chain Connection status. It is currently set to orange to when it is disconnected to the chain, white when connecting, and green when NEO is connected. We can set the colors as we like and is quite eye-catching to the user. 

![A2](https://user-images.githubusercontent.com/81087205/171355088-5ba3ed60-63b2-466a-9f3f-d1d27f69e2c3.png)

![A3](https://user-images.githubusercontent.com/81087205/171355321-421ce3cd-cf19-41fd-9c77-382fdf8c457e.png)

![A4](https://user-images.githubusercontent.com/81087205/171355355-7fcbee3f-1832-48d4-9dac-cbf24f11b710.png)

Note that this is in response to UI issue #124 as brought up by Erik.  However, per further discussion with him, it seems to have opened up a can of worms as to what 'active connection to a chain' really entails. See issue #137 for discussion therein.